### PR TITLE
Fix Error: short_audio_transcribe.py ValueError with whisper

### DIFF
--- a/scripts/short_audio_transcribe.py
+++ b/scripts/short_audio_transcribe.py
@@ -23,7 +23,7 @@ def transcribe_one(audio_path):
     print(f"Detected language: {max(probs, key=probs.get)}")
     lang = max(probs, key=probs.get)
     # decode the audio
-    options = whisper.DecodingOptions(beam_size=5, best_of=5)
+    options = whisper.DecodingOptions(beam_size=5)
     result = whisper.decode(model, mel, options)
 
     # print the recognized text


### PR DESCRIPTION
Hello Plachtaa

I think your recent update on `short_audio_transcribe.py` on line 26 `options = whisper.DecodingOptions(beam_size=5, best_of=5)` will raise a ValueError with whisper https://github.com/openai/whisper/blob/main/whisper/decoding.py#L563. This will result in no annotations for short audios. Since the error is raised in a try and except, no errors will be reported. 

I offer a solution by deleting the second param. 