### PR TITLE
修改继续训练的部分以及增加从零开始训练选项

### DIFF
--- a/finetune_speaker_v2.py
+++ b/finetune_speaker_v2.py
@@ -100,18 +100,26 @@ def run(rank, n_gpus, hps):
   # load existing model
   if hps.cont:
       try:
-          _, _, _, epoch_str = utils.load_checkpoint("./OUTPUT_MODEL/G_latest.pth", net_g, None)
-          _, _, _, epoch_str = utils.load_checkpoint("./OUTPUT_MODEL/D_latest.pth", net_d, None)
-          global_step = epoch_str * hps.train.batch_size
+          _, _, _, epoch_str = utils.load_checkpoint(utils.latest_checkpoint_path(hps.model_dir, "G_[0-9]*.pth"), net_g, None)
+          _, _, _, epoch_str = utils.load_checkpoint(utils.latest_checkpoint_path(hps.model_dir, "D_[0-9]*.pth"), net_d, None)
+          global_step = (epoch_str - 1) * len(train_loader)
       except:
           print("Failed to find latest checkpoint, loading G_0.pth...")
-          _, _, _, epoch_str = utils.load_checkpoint("./pretrained_models/G_0.pth", net_g, None)
-          _, _, _, epoch_str = utils.load_checkpoint("./pretrained_models/D_0.pth", net_d, None)
+          if hps.train_with_pretrained_model:
+              print("Train with pretrained model...")
+              _, _, _, epoch_str = utils.load_checkpoint("./pretrained_models/G_0.pth", net_g, None)
+              _, _, _, epoch_str = utils.load_checkpoint("./pretrained_models/D_0.pth", net_d, None)
+          else:
+              print("Train without pretrained model...")
           epoch_str = 1
           global_step = 0
   else:
-      _, _, _, epoch_str = utils.load_checkpoint("./pretrained_models/G_0.pth", net_g, None)
-      _, _, _, epoch_str = utils.load_checkpoint("./pretrained_models/D_0.pth", net_d, None)
+      if hps.train_with_pretrained_model:
+          print("Train with pretrained model...")
+          _, _, _, epoch_str = utils.load_checkpoint("./pretrained_models/G_0.pth", net_g, None)
+          _, _, _, epoch_str = utils.load_checkpoint("./pretrained_models/D_0.pth", net_d, None)
+      else:
+          print("Train without pretrained model...")
       epoch_str = 1
       global_step = 0
   # freeze all other layers except speaker embedding
@@ -256,13 +264,16 @@ def train_and_evaluate(rank, epoch, hps, nets, optims, schedulers, scaler, loade
         utils.save_checkpoint(net_g, None, hps.train.learning_rate, epoch,
                               os.path.join(hps.model_dir, "G_latest.pth".format(global_step)))
         utils.save_checkpoint(net_d, None, hps.train.learning_rate, epoch, os.path.join(hps.model_dir, "D_{}.pth".format(global_step)))
-        utils.save_checkpoint(net_d, None, hps.train.learning_rate, epoch,
-                              os.path.join(hps.model_dir, "D_latest.pth".format(global_step)))
-        old_g=os.path.join(hps.model_dir, "G_{}.pth".format(global_step-4000))
-        old_d=os.path.join(hps.model_dir, "D_{}.pth".format(global_step-4000))
+        # utils.save_checkpoint(net_d, None, hps.train.learning_rate, epoch,
+        #                       os.path.join(hps.model_dir, "D_latest.pth".format(global_step)))
+        old_g = utils.oldest_checkpoint_path(hps.model_dir, "G_[0-9]*.pth",
+                                             preserved=hps.preserved)  # Preserve 4 (default) historical checkpoints.
+        old_d = utils.oldest_checkpoint_path(hps.model_dir, "D_[0-9]*.pth", preserved=hps.preserved)
         if os.path.exists(old_g):
+          print(f"remove {old_g}")
           os.remove(old_g)
         if os.path.exists(old_d):
+          print(f"remove {old_d}")
           os.remove(old_d)
     global_step += 1
     if epoch > hps.max_epochs:

--- a/utils.py
+++ b/utils.py
@@ -293,6 +293,17 @@ def load_filepaths_and_text(filename, split="|"):
     return filepaths_and_text
 
 
+def str2bool(v):
+    if isinstance(v, bool):
+        return v
+    if v.lower() in ('yes', 'true', 't', 'y', '1'):
+        return True
+    elif v.lower() in ('no', 'false', 'f', 'n', '0'):
+        return False
+    else:
+        raise argparse.ArgumentTypeError('Boolean value expected.')
+
+
 def get_hparams(init=True):
     parser = argparse.ArgumentParser()
     parser.add_argument('-c', '--config', type=str, default="./configs/modified_finetune_speaker.json",
@@ -301,9 +312,9 @@ def get_hparams(init=True):
                         help='Model name')
     parser.add_argument('-n', '--max_epochs', type=int, default=50,
                         help='finetune epochs')
-    parser.add_argument('--cont', type=bool, default=False, help='whether to continue training on the latest checkpoint')
-    parser.add_argument('--drop_speaker_embed', type=bool, default=False, help='whether to drop existing characters')
-    parser.add_argument('--train_with_pretrained_model', type=bool, default=True,
+    parser.add_argument('--cont', type=str2bool, default=False, help='whether to continue training on the latest checkpoint')
+    parser.add_argument('--drop_speaker_embed', type=str2bool, default=False, help='whether to drop existing characters')
+    parser.add_argument('--train_with_pretrained_model', type=str2bool, default=True,
                         help='whether to train with pretrained model')
     parser.add_argument('--preserved', type=int, default=4,
                         help='Number of preserved models')

--- a/utils.py
+++ b/utils.py
@@ -204,12 +204,27 @@ def summarize(writer, global_step, scalars={}, histograms={}, images={}, audios=
         writer.add_audio(k, v, global_step, audio_sampling_rate)
 
 
-def latest_checkpoint_path(dir_path, regex="G_*.pth"):
+def extract_digits(f):
+    digits = "".join(filter(str.isdigit, f))
+    return int(digits) if digits else -1
+
+
+def latest_checkpoint_path(dir_path, regex="G_[0-9]*.pth"):
     f_list = glob.glob(os.path.join(dir_path, regex))
-    f_list.sort(key=lambda f: int("".join(filter(str.isdigit, f))))
+    f_list.sort(key=lambda f: extract_digits(f))
     x = f_list[-1]
-    print(x)
+    print(f"latest_checkpoint_path:{x}")
     return x
+
+
+def oldest_checkpoint_path(dir_path, regex="G_[0-9]*.pth", preserved=4):
+    f_list = glob.glob(os.path.join(dir_path, regex))
+    f_list.sort(key=lambda f: extract_digits(f))
+    if len(f_list) > preserved:
+        x = f_list[0]
+        print(f"oldest_checkpoint_path:{x}")
+        return x
+    return ""
 
 
 def plot_spectrogram_to_numpy(spectrogram):
@@ -288,6 +303,10 @@ def get_hparams(init=True):
                         help='finetune epochs')
     parser.add_argument('--cont', type=bool, default=False, help='whether to continue training on the latest checkpoint')
     parser.add_argument('--drop_speaker_embed', type=bool, default=False, help='whether to drop existing characters')
+    parser.add_argument('--train_with_pretrained_model', type=bool, default=True,
+                        help='whether to train with pretrained model')
+    parser.add_argument('--preserved', type=int, default=4,
+                        help='Number of preserved models')
 
     args = parser.parse_args()
     model_dir = os.path.join("./", args.model)
@@ -312,6 +331,8 @@ def get_hparams(init=True):
     hparams.max_epochs = args.max_epochs
     hparams.cont = args.cont
     hparams.drop_speaker_embed = args.drop_speaker_embed
+    hparams.train_with_pretrained_model = args.train_with_pretrained_model
+    hparams.preserved = args.preserved
     return hparams
 
 


### PR DESCRIPTION
作者您好！
您的项目非常易于上手，使用下来体验很棒！

在使用您的项目过程中，我遇到一些问题，以及出于增加训练自由度的目的，进行了以下改动并作出解释：

1.我修改了模型的输出路径，但发现继续训练里的模型加载路径固定为`./OUTPUT_MODEL`，于是我修改路径为模型拼接`hps.model_dir`，以便从传入的参数中读取路径。这样改了之后也可以把输出路径设置到谷歌云盘中，继续训练也可以从云盘中加载模型。

2.~注释掉了训练过程中保存`D_latest.pth`模型的这一步，修改继续训练中加载的模型名称为`G_[0-9]*.pth`和`D_[0-9]*.pth`。因为我发现D开头的模型大小一般有500mb，如果需要训练的步数比较多的时候保存在谷歌云盘下次再从云盘读取会比较方便，而少存一个D模型可以节省不少空间，所以我觉得只需要保存`G_latest.pth`  `G_[0-9]*.pth` `D_[0-9]*.pth`就好了。~

3.删除旧模型的逻辑改为读取旧模型的数量然后删除最旧的模型。因为我发现保存阈值比较小的时候，比如100step保存一个模型，`global_step-4000`会导致保存了很多模型才删除4000step之前的。当然保存旧模型的数量也是可以调的。

4.增加从零开始训练的选项，不加载预训练模型进行训练，让本项目不再只是微调。（因为我觉得作者您的项目很好用，但有时候也有从零开始训练的需求，所以就在您的项目里添加了。不过可能与您创建此项目的目标不同，您可以考虑要不要加这个）

5.`argparse`在命令行传入布尔类型的参数时，会当成字符类型而始终接收为`True`，所以增加了一个`str2bool`的函数。

另外colab现在自带的python好像是3.10，我修改了一份可用于现在colab环境的[requirements.txt](https://github.com/Plachtaa/VITS-fast-fine-tuning/files/11741721/requirements.txt)，可以直接用colab中已装好的库而节省安装依赖的时间，如果您有需要的话可以参考一下！

附上我使用的[colab notebook](https://colab.research.google.com/drive/1qaTzt59QUjExUdHOqFoqectin08VeXbB?usp=sharing)以供参考，最后再次感谢您的项目！

