### PR TITLE
Update preprocess_v2.py

### DIFF
--- a/preprocess_v2.py
+++ b/preprocess_v2.py
@@ -1,6 +1,9 @@
 import os
 import argparse
 import json
+import sys
+sys.setrecursionlimit(500000)  # fix the error message of RecursionError: maximum recursion depth exceeded while calling a Python object
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--add_auxiliary_data", type=bool, help="Whether to add extra data as fine-tuning helper")

--- a/preprocess_v2.py
+++ b/preprocess_v2.py
@@ -2,7 +2,7 @@ import os
 import argparse
 import json
 import sys
-sys.setrecursionlimit(500000)  # fix the error message of RecursionError: maximum recursion depth exceeded while calling a Python object
+sys.setrecursionlimit(500000)  # Fix the error message of RecursionError: maximum recursion depth exceeded while calling a Python object.  You can change the number as you want.
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
### Fix the error message of RecursionError: maximum recursion depth exceeded while calling a Python object

When running the command `$ python preprocess_v2.py --languages "CJE"` in local training environment

Although the preprocess_v2.py script ran successfully, but it would show the error message like this:

```
finished
Traceback (most recent call last):
  File "pyopenjtalk\openjtalk.pyx", line 159, in pyopenjtalk.openjtalk.OpenJTalk._clear
  File "pyopenjtalk\openjtalk.pyx", line 159, in pyopenjtalk.openjtalk.OpenJTalk._clear
  File "pyopenjtalk\openjtalk.pyx", line 159, in pyopenjtalk.openjtalk.OpenJTalk._clear
  [Previous line repeated 497 more times]
RecursionError: maximum recursion depth exceeded while calling a Python object
Exception ignored in: 'pyopenjtalk.openjtalk.OpenJTalk.__dealloc__'
Traceback (most recent call last):
  File "pyopenjtalk\openjtalk.pyx", line 159, in pyopenjtalk.openjtalk.OpenJTalk._clear
  File "pyopenjtalk\openjtalk.pyx", line 159, in pyopenjtalk.openjtalk.OpenJTalk._clear
  File "pyopenjtalk\openjtalk.pyx", line 159, in pyopenjtalk.openjtalk.OpenJTalk._clear
  [Previous line repeated 497 more times]
RecursionError: maximum recursion depth exceeded while calling a Python object
```

To ignore the error message, I add the following script:

```
import sys
sys.setrecursionlimit(500000)
```

