### PR TITLE
Update short_audio_transcribe.py to fix Whisper no short audios found issue

### DIFF
--- a/scripts/short_audio_transcribe.py
+++ b/scripts/short_audio_transcribe.py
@@ -16,7 +16,7 @@ def transcribe_one(audio_path):
     audio = whisper.pad_or_trim(audio)
 
     # make log-Mel spectrogram and move to the same device as the model
-    mel = whisper.log_mel_spectrogram(audio).to(model.device)
+    mel = whisper.log_mel_spectrogram(audio, n_mels=128).to(model.device)
 
     # detect the spoken language
     _, probs = model.detect_language(mel)


### PR DESCRIPTION
This change fixes this issue on step 3 of the colab for Whisper:

```
error: XDG_RUNTIME_DIR not set in the environment.
ALSA lib confmisc.c:855:(parse_card) cannot find card '0'
ALSA lib conf.c:5178:(_snd_config_evaluate) function snd_func_card_inum returned error: No such file or directory
ALSA lib confmisc.c:422:(snd_func_concat) error evaluating strings
ALSA lib conf.c:5178:(_snd_config_evaluate) function snd_func_concat returned error: No such file or directory
ALSA lib confmisc.c:1334:(snd_func_refer) error evaluating name
ALSA lib conf.c:5178:(_snd_config_evaluate) function snd_func_refer returned error: No such file or directory
ALSA lib conf.c:5701:(snd_config_expand) Evaluate error: No such file or directory
ALSA lib pcm.c:2664:(snd_pcm_open_noupdate) Unknown PCM default
ALSA lib confmisc.c:855:(parse_card) cannot find card '0'
ALSA lib conf.c:5178:(_snd_config_evaluate) function snd_func_card_inum returned error: No such file or directory
ALSA lib confmisc.c:422:(snd_func_concat) error evaluating strings
ALSA lib conf.c:5178:(_snd_config_evaluate) function snd_func_concat returned error: No such file or directory
ALSA lib confmisc.c:1334:(snd_func_refer) error evaluating name
ALSA lib conf.c:5178:(_snd_config_evaluate) function snd_func_refer returned error: No such file or directory
ALSA lib conf.c:5701:(snd_config_expand) Evaluate error: No such file or directory
ALSA lib pcm.c:2664:(snd_pcm_open_noupdate) Unknown PCM default
100%|██████████████████████████████████████| 2.88G/2.88G [00:13<00:00, 237MiB/s]
Warning: no long audios & videos found, this IS expected if you have only uploaded short audios
this IS NOT expected if you have uploaded any long audios, videos or video links. Please check your file structure or make sure your audio/video language is supported.
Warning: no short audios found, this IS expected if you have only uploaded long audios, videos or video links.
this IS NOT expected if you have uploaded a zip file of short audios. Please check your file structure or make sure your audio language is supported.
```